### PR TITLE
Add Let's Encrypt endpoint with ENV id/pass

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,9 @@
+class PagesController < ApplicationController
+  def letsencrypt
+    if params[:id] == ENV['LETS_ENCRYPT_ID']
+      render text: ENV['LETS_ENCRYPT_PASS']
+    else
+      render text: nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get '/.well-known/acme-challenge/:id' => 'pages#letsencrypt'
+
   mount Locomotive::Engine => '/admin', as: 'locomotive'
   mount Locomotive::API.to_app => '/locomotive(/:site_handle)/api'
   mount Locomotive::Steam.to_app => '/', anchor: false


### PR DESCRIPTION
In order to be able to easily renew the Let's Encrypt SSL certificate, add a permanent endpoint which pulls the proper ID and password from the `ENV` vars.